### PR TITLE
Turn public/index.php into a front controller #2

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ /index.php

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,6 @@
 <?php
 
 require __DIR__.'/../src/controllers/FrontController.php';
+require __DIR__.'/../src/controllers/RootController.php';
 
-$frontController = new FrontController();
-$frontController->run();
+(new FrontController())->run();

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,6 @@
 <?php
 
-require __DIR__.'/../src/controllers/RootController.php';
+require __DIR__.'/../src/controllers/FrontController.php';
 
-echo (new RootController)->get();
+$frontController = new FrontController();
+$frontController->run();

--- a/src/controllers/FrontController.php
+++ b/src/controllers/FrontController.php
@@ -1,0 +1,88 @@
+<?php
+
+require __DIR__ . '/../interfaces/FrontControllerInterface.php';
+
+class FrontController implements FrontControllerInterface
+{
+    const DEFAULT_CONTROLLER = "RootController";
+    const DEFAULT_ACTION = "get";
+
+    protected $controller = self::DEFAULT_CONTROLLER;
+    protected $action = self::DEFAULT_ACTION;
+    protected $params = array();
+
+    public function __construct(array $options = array())
+    {
+        if (empty($options)) {
+            $this->parseUri();
+        } else {
+            if (isset($options["controller"])) {
+                $this->setController($options["controller"]);
+            }
+
+            if (isset($options["action"])) {
+                $this->setAction($options["action"]);
+            }
+
+            if (isset($options["params"])) {
+                $this->setParams($options["params"]);
+            }
+        }
+    }
+
+    protected function parseUri()
+    {
+        $path = trim(parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH), "/");
+        $path = preg_replace('/[^a-zA-Z0-9]//', "", $path);
+
+        @list($controller, $action, $params) = explode("/", $path, 3);
+
+        if (isset($controller)) {
+            $this->setController($controller);
+        }
+
+        if (isset($action)) {
+            $this->setAction($action);
+        }
+
+        if (isset($params)) {
+            $this->setParams(explode("/", $params));
+        }
+    }
+
+    public function setController($controller)
+    {
+        $controller = ucfirst(strtolower($controller)) . "Controller";
+        if (!class_exists($controller)) {
+            throw new InvalidArgumentException(
+                "The action controller '$controller' has not been defined.");
+        }
+        $this->controller = $controller;
+
+        return $this;
+    }
+
+    public function setAction($action)
+    {
+        $reflector = new ReflectionClass($this->controller);
+        if (!$reflector->hasMethod($action)) {
+            throw new InvalidArgumentException(
+                "The controller action '$action' has been not defined.");
+        }
+        $this->action = $action;
+
+        return $this;
+    }
+
+    public function setParams(array $params)
+    {
+        $this->params = $params;
+
+        return $this;
+    }
+
+    public function run()
+    {
+        call_user_func_array(array(new $this->controller, $this->action), $this->params);
+    }
+}

--- a/src/controllers/RootController.php
+++ b/src/controllers/RootController.php
@@ -4,10 +4,11 @@ require __DIR__.'/Controller.php';
 
 require __DIR__.'/../models/FooBarBaz.php';
 
-class RootController extends Controller {
-
-    public function get(): string {
-        return view('root', [
+class RootController extends Controller
+{
+    public function get(): void
+    {
+        echo view('root', [
             'title' => 'hello world',
             'array' => FooBarBaz::get(),
         ]);

--- a/src/interfaces/FrontControllerInterface.php
+++ b/src/interfaces/FrontControllerInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface FrontControllerInterface
+{
+    public function setController($controller);
+    public function setAction($action);
+    public function setParams(array $params);
+    public function run();
+}

--- a/src/interfaces/FrontControllerInterface.php
+++ b/src/interfaces/FrontControllerInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-interface FrontControllerInterface
-{
-    public function setController($controller);
-    public function setAction($action);
-    public function setParams(array $params);
-    public function run();
-}


### PR DESCRIPTION
Added support for front controller (#2):

.htaccess to rewrite requests to index.php

Requests are written as follows: /{Controller}/{Action}/{Params}

So /Test/Edit/123 would call the Edit() method of the TestController with the param 123 ($id).

It is setup to default to RootController->get();

Note: The controllers now return a response themselves (echo).